### PR TITLE
Fix error on static call

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -98,9 +98,9 @@ class MysqliDb
     {
         $this->_where = array();
         $this->_bindParams = array(''); // Create the empty 0 index
-        unset($this->_query);
-        unset($this->_whereTypeList);
-        unset($this->_paramTypeList);
+        $this->_query = '';
+        $this->_whereTypeList = '';
+        $this->_paramTypeList = '';
     }
 
     /**


### PR DESCRIPTION
using where method on $db = MysqliDb::getInstance(); causes error
