### PR TITLE
Add mysqli->ping functionality

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -472,4 +472,16 @@ class MysqliDb
         return $arr;
     }
 
+    /**
+     * Simple addition to allow mysqli->ping() to keep unused connections open on
+     * long-running scripts, or to reconnect timed out connections (if php.ini has 
+     * global mysqli.reconnect set to true). Can't do this directly using object 
+     * since _mysqli is protected.
+     * 
+     * @return bool True if connection is up
+     */
+    public function ping()
+    {
+        return $this->_mysqli->ping();
+    }
 } // END class


### PR DESCRIPTION
Since _mysqli is protected, we can't run a mysli->ping on the connection from the instantiated object. This public function exposes it so we can keep an idle connection open if desired, or to reconnect if the server disconnected us.