### PR TITLE
Allowing null in WHERE syntax

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -464,7 +464,7 @@ class MysqliDb
                     // Determines what data type the where column is, for binding purposes.
                     $this->_whereTypeList .= $this->_determineType($value);
                 }
-                
+                // Check if given value for column is null and using proper sysntax to check if is null in stmt
                 if (!isset($value))
                    $comparison = "<=> ?";
                 // Prepares the reset of the SQL query.

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -463,10 +463,11 @@ class MysqliDb
                 } else {
                     // Determines what data type the where column is, for binding purposes.
                     $this->_whereTypeList .= $this->_determineType($value);
+                    // Check if given value for column is null and using proper sysntax to check if is null in stmt
+                    if (!isset($value))
+                       $comparison = "<=> ?";
                 }
-                // Check if given value for column is null and using proper sysntax to check if is null in stmt
-                if (!isset($value))
-                   $comparison = "<=> ?";
+                
                 // Prepares the reset of the SQL query.
                 $this->_query .= ($column.$comparison.' AND ');
             }

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -464,6 +464,9 @@ class MysqliDb
                     // Determines what data type the where column is, for binding purposes.
                     $this->_whereTypeList .= $this->_determineType($value);
                 }
+                
+                if (!isset($value))
+                   $comparison = "<=> ?";
                 // Prepares the reset of the SQL query.
                 $this->_query .= ($column.$comparison.' AND ');
             }


### PR DESCRIPTION
Basically you can insert NULL's into database, but you cannot select rows by "where column is null".

The right syntax to do that (after a few tens of minutes of research) is column <=> (null binded variable).

Anyway. This fix allows you to use the syntax normally ->where("column", NULL) and it will create the proper prepared statement.