### PR TITLE
store result

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -675,6 +675,7 @@ class MysqliDb
             $parameters[] = & $row[$field->name];
         }
 
+        $stmt->store_result();
         call_user_func_array(array($stmt, 'bind_result'), $parameters);
 
         while ($stmt->fetch()) {


### PR DESCRIPTION
there was an bug on php 5.2, 5.3 (https://bugs.php.net/bug.php?id=47928) and when use longtext column system giving an error like "Allowed memory size" $stmt->store_result(); fix that problem.