### PR TITLE
Add composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+	"name": "joshcam/PHP-MySQLi-Database-Class",
+	"description": "Wrapper for a PHP MySQL class, which utilizes MySQLi and prepared statements.",
+	"license": "GPL-3.0",
+	"require": {
+		"php": ">=5.3.0"
+	},
+	"autoload": {
+		"files": ["MysqliDb.php"]
+	}
+}


### PR DESCRIPTION
Adding a composer.json file to allow this library to be installed using composer.

This would (at least partially) take care of joshcam/PHP-MySQLi-Database-Class#134 and joshcam/PHP-MySQLi-Database-Class#153