### PR TITLE
Swapped trigger_error for exceptions

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1487,4 +1487,3 @@ class MysqliDb
         return $this->count == $count;
     }
 } // END class
-?>

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1189,7 +1189,7 @@ class MysqliDb
     protected function _prepareQuery()
     {
         if (!$stmt = $this->mysqli()->prepare($this->_query)) {
-            trigger_error("Problem preparing query ($this->_query) " . $this->mysqli()->error, E_USER_ERROR);
+            throw new Exception("Problem preparing query ($this->_query) " . $this->mysqli()->error);
         }
         if ($this->traceEnabled)
             $this->traceStartQ = microtime (true);
@@ -1314,7 +1314,7 @@ class MysqliDb
             if (!empty ($matches[2])) $items = $matches[2];
             if (!empty ($matches[3])) $type = $matches[3];
             if (!in_array($type, array_keys($types)))
-                trigger_error ("invalid interval type in '{$diff}'");
+                throw new Exception("invalid interval type in '{$diff}'");
             $func .= " ".$incr ." interval ". $items ." ".$types[$type] . " ";
         }
         return $func;
@@ -1341,7 +1341,7 @@ class MysqliDb
      */
     public function inc($num = 1) {
         if(!is_numeric($num)){
-            trigger_error('Argument supplied to inc must be a number', E_USER_ERROR);
+            throw new Exception('Argument supplied to inc must be a number');
         }
         return Array ("[I]" => "+" . $num);
     }
@@ -1352,7 +1352,7 @@ class MysqliDb
      */
     public function dec ($num = 1) {
         if(!is_numeric($num)){
-            trigger_error('Argument supplied to dec must be a number', E_USER_ERROR);
+            throw new Exception('Argument supplied to dec must be a number');
         }
         return Array ("[I]" => "-" . $num);
     }

--- a/dbObject.php
+++ b/dbObject.php
@@ -688,4 +688,3 @@ class dbObject {
         spl_autoload_register ("dbObject::dbObjectAutoload");
     }
 }
-?>


### PR DESCRIPTION
It seems more convenient/conventional to throw exceptions so they can be
caught, if desired.  Using trigger_error creates a fatal error.