### PR TITLE
Join: do not add 'on' if using() condition is used

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1225,7 +1225,9 @@ class MysqliDb
                 $joinStr = $joinTable;
             }
 
-            $this->_query .= " " . $joinType . " JOIN " . $joinStr . " " . $joinCondition;
+            $this->_query .= " " . $joinType . " JOIN " . $joinStr . 
+                (false === stripos('using', $joinCondition) ? " " : " on ") 
+                . $joinCondition;
         }
     }
 

--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1225,7 +1225,7 @@ class MysqliDb
                 $joinStr = $joinTable;
             }
 
-            $this->_query .= " " . $joinType . " JOIN " . $joinStr . " on " . $joinCondition;
+            $this->_query .= " " . $joinType . " JOIN " . $joinStr . " " . $joinCondition;
         }
     }
 


### PR DESCRIPTION
### Tables
 
```sql
CREATE TABLE IF NOT EXISTS `users` (
  `user_id` int(11) NOT NULL auto_increment,
  `username` varchar(50) NOT NULL,
  PRIMARY KEY  (`user_id`)
) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=1 ;

CREATE TABLE IF NOT EXISTS `users_profiles` (
  `id` int(11) NOT NULL auto_increment,
  `user_id` int(11) NOT NULL,
  `real_name` varchar(20) NOT NULL,
  `birthday_time` int(11) NOT NULL,
) ENGINE=MyISAM  DEFAULT CHARSET=utf8 AUTO_INCREMENT=3 ;
```
### Code
```php
$db->join("users_profiles", "using(user_id)", "LEFT")
->where( 'user_id',  $id)
->get('users');
```
### before

Fatal error: Uncaught exception 'Exception' with message 'Problem preparing query (SELECT * FROM a_users LEFT JOIN a_users_profiles on using(user_id) WHERE user_id = ? ) You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'using(user_id) WHERE user_id = ?' at line 1

### After

```php
array (size=5)
      'user_id' => int 1
      'username' => string 'Admin' (length=5)
      'id' => int 1
      'real_name' => string '' (length=0)
      'birthday_time' => int 0
```