### PR TITLE
fix $obj->relatedObj === null when not exists and fieldList

### DIFF
--- a/dbObject.php
+++ b/dbObject.php
@@ -527,7 +527,13 @@ class dbObject {
                     $data[$name] = $this->$name;
                     continue;
                 } 
-                if ($data[$table][$primaryKey] === null) {
+                $hasOne = false;
+                foreach ($data[$table] as $field=>$value) {
+                    if ($hasOne === true) continue;
+                    if ($value !== null) $hasOne = true;
+                }
+				
+                if ($hasOne === false) {
                     $data[$name] = null;
                 } else {
                     if ($this->returnType == 'Object') {


### PR DESCRIPTION
     $firstObj = file::with('secondObj')->ById($firstId,'FirstTableField, SecondTableField(s)NoPrimary');
     print_r($firstObj->secondObj === null); // Before return error, now work

BUT - WARNING -
if SecondTableField(s)NoPrimary has a === null value , this return same $firstObj->secondObj === null as secondObj not exist...
I don't know so fix this... anyway is a little bug.