### PR TITLE
fixed missing space before operator when comparing against NULL

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1396,7 +1396,7 @@ class MysqliDb
                     if (is_array($val)) {
                         $this->_bindParams($val);
                     } elseif ($val === null) {
-                        $this->_query .= $operator . " NULL";
+                        $this->_query .= ' ' . $operator . " NULL";
                     } elseif ($val != 'DBNULL' || $val == '0') {
                         $this->_query .= $this->_buildPair($operator, $val);
                     }

--- a/tests/dbObjectTests.php
+++ b/tests/dbObjectTests.php
@@ -1,4 +1,4 @@
-<?
+<?php
 error_reporting (E_ALL|E_STRICT);
 require_once ("../MysqliDb.php");
 require_once ("../dbObject.php");


### PR DESCRIPTION
- added missing space ' '  befor appending operator to query in _buildCondition() default statement for NULL comparison
- changed shorthand php `<?` to default `<?php` in dbObjectTests for better downward compability