### PR TITLE
insertMulti implementation by using transactions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,43 @@ $db->onDuplicate($updateColumns, $lastInsertId);
 $id = $db->insert ('users', $data);
 ```
 
+Insert multiple datasets at once
+```php
+$data = Array(
+    Array ("login" => "admin",
+        "firstName" => "John",
+        "lastName" => 'Doe'
+    ),
+    Array ("login" => "other",
+        "firstName" => "Another",
+        "lastName" => 'User',
+        "password" => "very_cool_hash"
+    )
+);
+$ids = $db->insertMulti('users', $data);
+if(!$ids) {
+    echo 'insert failed: ' . $db->getLastError();
+} else {
+    echo 'new users inserted with following id\'s: ' . implode(', ', $ids);
+}
+```
+
+If all datasets only have the same keys, it can be simplified
+```php
+$data = Array(
+    Array ("admin", "John", "Doe"),
+    Array ("other", "Another", "User")
+);
+$keys = Array("login", "firstName", "lastName");
+
+$ids = $db->insertMulti('users', $data, $keys);
+if(!$ids) {
+    echo 'insert failed: ' . $db->getLastError();
+} else {
+    echo 'new users inserted with following id\'s: ' . implode(', ', $ids);
+}
+```
+
 ### Replace Query
 <a href='https://dev.mysql.com/doc/refman/5.0/en/replace.html'>Replace()</a> method implements same API as insert();
 


### PR DESCRIPTION
this is a first implementation for `MysqliDB:: insertMulti()` method to insert multiple datasets at once by utilizing mysql-transactions.

Please excuse the additional changed lines in the commits, where only spaces where deleted. My Editor does this by default.

This is only a proposal and therefor may be not the best or fastest solution.

The changes include:
 -  added `MysqliDB::insertMulti()` method into `MysqliDb.php`
 - added tests for insertMulti implementation in `tests/mysqliDbTests.php`
 - added small documentation to `readme.md`

Please tell, if something should be changed or does not adapt the classes coding style.