### PR TITLE
 update 语句应该返回受影响行数,否则即使更新一个where条件无效数据也会返回true

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -671,7 +671,7 @@ class MysqliDb
      * @param array  $tableData Array of data to update the desired row.
      * @param int    $numRows   Limit on the number of rows that can be updated.
      *
-     * @return bool
+     * @return int 
      */
     public function update($tableName, $tableData, $numRows = null)
     {
@@ -688,7 +688,7 @@ class MysqliDb
         $this->_stmtErrno = $stmt->errno;
         $this->count = $stmt->affected_rows;
 
-        return $status;
+        return $this->count;
     }
 
     /**


### PR DESCRIPTION
# Fixed Bug

 > UPDATE statement should return the number of affected bars

```
example:

$result     = $db->where ('userid', "18#abc")->getOne("userinfo");
var_dump(#result);  // null

$data       = ['nickname'=>'jokechat'];
$result     = $db->where ('userid', "18#abc")->update("userinfo",$data);
var_dump($result);  //bool(true)

After repair:
$data       = ['nickname'=>'jokechat'];
$result     = $db->where ('userid', "18#abc")->update("userinfo",$data);
var_dump($result);  //int(0)

```