### PR TITLE
Don't check for empty dbFields on update

### DIFF
--- a/dbObject.php
+++ b/dbObject.php
@@ -244,9 +244,6 @@ class dbObject {
      * @param array $data Optional update data to apply to the object
      */
     public function update ($data = null) {
-        if (empty ($this->dbFields))
-            return false;
-
         if (empty ($this->data[$this->primaryKey]))
             return false;
 


### PR DESCRIPTION
This makes save() work without having to define $dbFields in the model.