### PR TITLE
Add "hidden" columns/fields into dbObject

### DIFF
--- a/dbObject.md
+++ b/dbObject.md
@@ -295,6 +295,42 @@ $products = product::arraybuilder()->paginate($page);
 echo "showing $page out of " . product::$totalPages;
 
 ```
+
+###Hidden Fields
+Sometimes it's important to block some fields that can be accessed from outside the model class (for example, the user password).
+
+To block the access to certain fields using the `->` operator, you can declare the  `$hidden` array into the model class. This array holds column names that can't be accessed with the `->` operator.
+
+For example:
+
+```php
+class User extends dbObject {
+    protected $dbFields = array(
+        'username' => array('text', 'required'),
+        'password' => array('text', 'required'),
+        'is_admin' => array('bool'),
+        'token' => array('text')
+    );
+
+    protected $hidden = array(
+        'password', 'token'
+    );
+}
+```
+
+If you try to:
+```php
+echo $user->password;
+echo $user->token;
+```
+
+Will return `null`, and also:
+```php
+$user->password = "my-new-password";
+```
+
+Won't change the current `password` value.
+
 ###Examples
 
 Please look for a use examples in <a href='tests/dbObjectTests.php'>tests file</a> and test models inside the <a href='tests/models/'>test models</a> directory

--- a/dbObject.php
+++ b/dbObject.php
@@ -138,7 +138,7 @@ class dbObject {
      * @return mixed
      */
     public function __get ($name) {
-        if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
+        if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) !== false)
 	    return null;
 		
 	if (isset ($this->data[$name]) && $this->data[$name] instanceof dbObject)

--- a/dbObject.php
+++ b/dbObject.php
@@ -124,9 +124,6 @@ class dbObject {
      * @return mixed
      */
     public function __set ($name, $value) {
-	if ($name === 'hidden')
-            return;
-        
         if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) !== false)
             return;
 	    
@@ -141,12 +138,11 @@ class dbObject {
      * @return mixed
      */
     public function __get ($name) {
-        if ($name === 'hidden') /* Just in case... */
-            return null;
-        
-        if (isset ($this->data[$name]) && $this->data[$name] instanceof dbObject)
-            if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
-                return $this->data[$name];
+        if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
+	    return null;
+		
+	if (isset ($this->data[$name]) && $this->data[$name] instanceof dbObject)
+            return $this->data[$name];
 
         if (property_exists ($this, 'relations') && isset ($this->relations[$name])) {
             $relationType = strtolower ($this->relations[$name][0]);
@@ -170,8 +166,7 @@ class dbObject {
         }
 
         if (isset ($this->data[$name]))
-            if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
-                return $this->data[$name];
+            return $this->data[$name];
 
         if (property_exists ($this->db, $name))
             return $this->db->$name;

--- a/dbObject.php
+++ b/dbObject.php
@@ -124,6 +124,12 @@ class dbObject {
      * @return mixed
      */
     public function __set ($name, $value) {
+	if ($name === 'hidden')
+            return;
+        
+        if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) !== false)
+            return;
+	    
         $this->data[$name] = $value;
     }
 
@@ -135,8 +141,12 @@ class dbObject {
      * @return mixed
      */
     public function __get ($name) {
+        if ($name === 'hidden') /* Just in case... */
+            return null;
+        
         if (isset ($this->data[$name]) && $this->data[$name] instanceof dbObject)
-            return $this->data[$name];
+            if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
+                return $this->data[$name];
 
         if (property_exists ($this, 'relations') && isset ($this->relations[$name])) {
             $relationType = strtolower ($this->relations[$name][0]);
@@ -159,9 +169,9 @@ class dbObject {
             }
         }
 
-        if (isset ($this->data[$name])) {
-            return $this->data[$name];
-        }
+        if (isset ($this->data[$name]))
+            if (property_exists ($this, 'hidden') && array_search ($name, $this->hidden) === false)
+                return $this->data[$name];
 
         if (property_exists ($this->db, $name))
             return $this->db->$name;


### PR DESCRIPTION
In current version, every column of a table mapped into a `dbObject` is accessible through the magic getter method and editable through magic setter method. 

But sometimes it's important to hide some fields/columns from the model (for example, access user password with `$user->password` is not that good, as updating it with `$user->password = "random"`).

I've added a `$hidden` array, that holds column names that can't be accessed with magic methods. This array must be declared into the model class, as the other arrays supported by the library.

```php
class User extends dbObject {
    protected $dbFields = array(
        'username' => array('text', 'required'),
        'password' => array('text', 'required'),
        'is_admin' => array('bool'),
        'token' => array('text')
    );

    protected $hidden = array(
        'password', 'token'
    );
}
```

If you try to:
```php
echo $user->password;
echo $user->token;
```

Will return `null`, and also:
```php
$user->password = "my-new-password";
```

Won't change the current "password" value.