### PR TITLE
FIX #661: Incorrect switch case

### DIFF
--- a/dbObject.php
+++ b/dbObject.php
@@ -641,7 +641,7 @@ class dbObject {
                 continue;
 
             switch ($type) {
-                case "text";
+                case "text":
                     $regexp = null;
                     break;
                 case "int":


### PR DESCRIPTION
dbObject has a switch case in line 644 : written as ";" .