### PR TITLE
Exception thrown when performing a query with syntax errors had ' query: ' message instead of detailed explanation with query text and error number. Fixed.

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -1908,9 +1908,12 @@ class MysqliDb
             $this->autoReconnectCount++;
             return $this->_prepareQuery();
         }
-        
+       
+        $error = $this->mysqli()->error;
+        $query = $this->_query;
+        $errno = $this->mysqli()->errno;
         $this->reset();
-        throw new Exception(sprintf('%s query: %s', $this->mysqli()->error, $this->_query), $this->mysqli()->errno);
+        throw new Exception(sprintf('%s query: %s', $error, $query), $errno);
 
         release:
         if ($this->traceEnabled) {


### PR DESCRIPTION
**How to reproduce the issue**
```php
<?php

include('MysqliDb.php');

$db = new MysqliDb('localhost', 'user', 'password', 'database');

try {
    $db->connection('default')->query('NOPE');
} catch (Exception $e) {
    echo $e->getMessage();
}
```

**Expected behavior**

Exception thrown with the following message:
```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'NOPE' at line 1 query: NOPE
```

**Actual behavior**

Exception thrown with the following message:
```
 query: 
```
