### PR TITLE
use default connection when not specified

### DIFF
--- a/MysqliDb.php
+++ b/MysqliDb.php
@@ -269,7 +269,7 @@ class MysqliDb
      * @throws Exception
      * @return void
      */
-    public function connect($connectionName)
+    public function connect($connectionName = 'default')
     {
         if(!isset($this->connectionsSettings[$connectionName]))
             throw new Exception('Connection profile not set');


### PR DESCRIPTION
with this change we are able to call this MySQLi Database Class the same way as before.